### PR TITLE
let Jest Support ElasticSearch 6.3.1

### DIFF
--- a/jest-common/src/main/java/io/searchbox/indices/aliases/GetAliases.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/GetAliases.java
@@ -20,7 +20,7 @@ public class GetAliases extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        return super.buildURI() + "/_aliases";
+        return super.buildURI() + "/_alias";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<GetAliases, Builder> {

--- a/jest-common/src/test/java/io/searchbox/indices/aliases/GetAliasesTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/aliases/GetAliasesTest.java
@@ -12,7 +12,7 @@ public class GetAliasesTest {
         GetAliases getAliases = new GetAliases.Builder().addIndex("twitter").build();
 
         assertEquals("GET", getAliases.getRestMethodName());
-        assertEquals("twitter/_aliases", getAliases.getURI());
+        assertEquals("twitter/_alias", getAliases.getURI());
     }
 
     @Test


### PR DESCRIPTION
I Upgrade Graylog Server to Support ElasticSearch 6.3.1,in 6.3.1,The  `/_all/_aliases` api is not support,it will throw this error
`
Incorrect HTTP method for uri [/_all/_aliases] and method [GET], allowed: [PUT]
`
so i change the `_aliases` to `_alias`.it work...